### PR TITLE
Can heal while soul meter broken

### DIFF
--- a/FastHealingSystem.cs
+++ b/FastHealingSystem.cs
@@ -47,6 +47,10 @@ namespace SilksongHealing
             {
                 StartCoroutine(HealThreeMasks());
             }
+            else if (global::InputHandler.Instance.inputActions.cast.WasPressed && isCharmEquipped() && !global::GameManager.instance.IsMenuScene())
+            {
+                StartCoroutine(HealThreeMasks());
+            }
         }
 
         private bool isCharmEquipped()


### PR DESCRIPTION
I checked and soulLimited is the thing for broken soul meter, also the isMenuScene should prevent healing while in dialogue with npcs